### PR TITLE
Keep to open lua state

### DIFF
--- a/src/emcc-lua
+++ b/src/emcc-lua
@@ -61,7 +61,7 @@ def main():
     bundle_files += glob.glob(LUAROCKS_LOCAL_MODULE_DIR + '/lib/lua/**/*.so', recursive=True)
     bundle_files += glob.glob(LUAROCKS_LOCAL_MODULE_DIR + '/share/lua/**/*.lua', recursive=True)
 
-    debug_print('===Start to factory and distinguish module files')
+    debug_print('Start to factory and distinguish module files')
 
     for bundle in bundle_files:
         if is_lua_source_file(bundle):

--- a/src/main.c
+++ b/src/main.c
@@ -110,6 +110,7 @@ int main(void) {
   if (boot_lua(wasm_lua_state)) {
     printf("failed to boot lua runtime\\n");
     lua_close(wasm_lua_state);
+    return 1;
   }
   printf("Boot Lua Webassembly!\n");
   return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -9,6 +9,7 @@
 #include <emscripten.h>
 
 int boot_lua(lua_State* L);
+static lua_State *wasm_lua_state = NULL;
 
 // Pre-compiled lua loader program
 static const unsigned char program[] = {__LUA_BASE__};
@@ -105,6 +106,11 @@ static int docall (lua_State *L, int narg, int nres) {
 
 // Boot function
 int main(void) {
+  wasm_lua_state = luaL_newstate();
+  if (boot_lua(wasm_lua_state)) {
+    printf("failed to boot lua runtime\\n");
+    lua_close(wasm_lua_state);
+  }
   printf("Boot Lua Webassembly!\n");
   return 0;
 }


### PR DESCRIPTION
On boot WASM program, initialize `lua_State` at `main()` function and reuse it on some functions.

Note that after this changes, no longer the WASM program close lua_State, so we have to take care of memory leak or something.