### PR TITLE
Ensure lua_State is initialized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ luac.out
 wasm.js
 wasm.wasm
 __pycache__
+examples/hello_world.js
+examples/hello_world.wasm

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>WASM Lua Exmaple</title>
+  </head>
+  <body>
+    <script>
+    var Module = {};
+    Module.onRuntimeInitialized = () => {
+      const helloWorld = Module.cwrap('hello_world', 'string');
+      console.log(helloWorld());
+    };
+    </script>
+    <script async src="hello_world.js"></script>
+  </body>
+</html>
+

--- a/src/emcc-lua
+++ b/src/emcc-lua
@@ -95,10 +95,6 @@ def main():
                 print(NM + ' command failed')
                 return
 
-    if len(lua_files) == 0:
-        print("no bundle files.")
-        return
-
     debug_print('===== Bundle Lua files ======')
     debug_print('\n'.join([v.filepath for v in lua_files]))
     debug_print('===== Library files =====')
@@ -160,7 +156,7 @@ def main():
     cmd.extend(['/tmp/compile.c', quote('/lua-{}/src/liblua.a'.format(os.environ.get('LUA_VERSION')))])
     cmd.extend([quote(v.filepath) for v in link_libraries])
     cmd.extend([quote(v.filepath) for v in link_libraries])
-    cmd.extend(['-lm', '-ldl', '-o', '{}.html'.format(output_target), '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["cwrap"]'])
+    cmd.extend(['-lm', '-ldl', '-o', '{}.js'.format(output_target), '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["cwrap"]'])
 
     debug_print('Compile command is {}'.format(' '.join(cmd)))
     shell_exec(*cmd)

--- a/src/emcc_lua_lib/definition.py
+++ b/src/emcc_lua_lib/definition.py
@@ -37,6 +37,10 @@ class Definition():
         template = '''
 EMSCRIPTEN_KEEPALIVE
 {} {}({}) {{
+  if (wasm_lua_state == NULL) {{
+    wasm_lua_state = luaL_newstate();
+    boot_lua(wasm_lua_state);
+  }}
   // Push arguments
   lua_getglobal(wasm_lua_state, "{}");
   if (!lua_isfunction(wasm_lua_state, -1)) {{

--- a/src/main.c
+++ b/src/main.c
@@ -19,39 +19,39 @@ static const unsigned char lua_main_program[] = {__LUA_MAIN__};
 // This line will be injected by emcc-lua as export functions to WASM declaration
 __LUA_FUNCTION_DECLARATIONS__
 
-// This function is for debuggin to see an C <-> Lua stack values
-void dumpStack(lua_State *L) {
-  int i;
-  int stackSize = lua_gettop(L);
-  for (i = stackSize; i >= 1; i--) {
-    int stackType = lua_type(L, i);
-    printf("Stack[%2d-%10s]:", i, lua_typename(L, stackType));
-
-    switch (stackType) {
-      case LUA_TNUMBER:
-        printf("%f", lua_tonumber(L, i));
-        break;
-      case LUA_TBOOLEAN:
-        if (lua_toboolean(L, i)) {
-          printf("true");
-        } else {
-          printf("false");
-        }
-        break;
-      case LUA_TSTRING:
-        printf("%s", lua_tostring(L, i));
-        break;
-      case LUA_TNIL:
-        printf("nil");
-        break;
-      default:
-        printf("%s", lua_typename(L, stackType));
-        break;
-    }
-    printf("\n");
-  }
-  printf("\n");
-}
+// This function is for debug to see an C <-> Lua stack values
+// void dumpStack(lua_State *L) {
+//   int i;
+//   int stackSize = lua_gettop(L);
+//   for (i = stackSize; i >= 1; i--) {
+//     int stackType = lua_type(L, i);
+//     printf("Stack[%2d-%10s]:", i, lua_typename(L, stackType));
+// 
+//     switch (stackType) {
+//       case LUA_TNUMBER:
+//         printf("%f", lua_tonumber(L, i));
+//         break;
+//       case LUA_TBOOLEAN:
+//         if (lua_toboolean(L, i)) {
+//           printf("true");
+//         } else {
+//           printf("false");
+//         }
+//         break;
+//       case LUA_TSTRING:
+//         printf("%s", lua_tostring(L, i));
+//         break;
+//       case LUA_TNIL:
+//         printf("nil");
+//         break;
+//       default:
+//         printf("%s", lua_typename(L, stackType));
+//         break;
+//     }
+//     printf("\n");
+//   }
+//   printf("\n");
+// }
 
 /* Copied from lua.c */
 
@@ -106,6 +106,9 @@ static int docall (lua_State *L, int narg, int nres) {
 
 // Boot function
 int main(void) {
+  if (wasm_lua_state != NULL) {
+    return 0;
+  }
   wasm_lua_state = luaL_newstate();
   if (boot_lua(wasm_lua_state)) {
     printf("failed to boot lua runtime\\n");


### PR DESCRIPTION
The `emscripten` says:

```
The main() function is called after startup is complete as a signal that it is safe to call any compiled method.
```

at https://kripken.github.io/emscripten-site/docs/getting_started/FAQ.html#how-can-i-tell-when-the-page-is-fully-loaded-and-it-is-safe-to-call-compiled-functions

So, at the client side, `Module.onRuntimeInitialized` is called before `main()` is called which is set up `lua_State`, then exported function may cause invalid memory access.

We have to care about it, and in order to do it, we always ensure the `lua_State` is `NOT` NULL before call functions, for make it safety.