### PR TITLE
Support output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Write and compile as WebAssembly program by lua script.
 - [lua](https://www.lua.org/) (prefer to use latest version)
 - Python 3.6.5+
 
-To avoid to polute your environment, we prefer to use prebuilt docker image on [docker image](https://hub.docker.com/r/ysugimoto/webassembly-lua/).
+To avoid to polute your environment, we *stringly* prefer to use prebuilt docker image on [docker hub](https://hub.docker.com/r/ysugimoto/webassembly-lua/).
 
 ## How to use
 
@@ -28,7 +28,7 @@ Make sure the function declares as *global* in order to access from C program.
 And, also you can spcify some function arguments like:
 
 ```lua
-function hell_something(something):
+function hello_something(something):
   return ('Hello, %s!'):format(something)
 end
 ```
@@ -50,17 +50,19 @@ functions:
       - string
 
 entry_file: hello_world.lua
+output_file: hello_world.html
 ```
 
 Describes each fields:
 
 | Field                  | Type    | Default  | description                                                                    |
-|:----------------------:|:-------:|:--------:|:-------------------------------------------------------------------------------|
+|:-----------------------|:-------:|:--------:|:-------------------------------------------------------------------------------|
 | dependencies           | array   | -        | program dependencies. the list of modules will be installed via `luarocks`.    |
 | functions              | object  | -        | Function definitions. The key is function name which will be exported on WASM. |
 | functions[name].return | string  | -        | Define function return type.                                                   |
 | functions[name].args   | array   | -        | Defined function argument type list.                                           |
 | entry_file             | strring | main.lua | the file name of program entry.                                                |
+| output_file            | strring | -        | the file name of output files.                                                 |
 
 ### Compile as WebAssembly program
 
@@ -71,7 +73,7 @@ $ docker pull ysugimoto/webassembly-lua
 $ docker run --rm -v $PWD:/src ysugimoto/webassembly-lua emcc-lua
 ```
 
-The `emcc-lua` finds `definition.yml in current working directory (in this case, `$PWD`) and start to build.
+The `emcc-lua` finds `definition.yml` in current working directory (in this case, `$PWD`) and start to build.
 If build successfully, you can see a `hello_world.[html,js,wasm]` in your directory. The output file is named by `entry_file` in definition.yml.
 
 ### Run WebAssembly program

--- a/examples/definition.yml
+++ b/examples/definition.yml
@@ -1,4 +1,5 @@
 entry_file: hello_world.lua
+output_file: hello_world.js
 
 functions:
   hello_world:

--- a/src/emcc-lua
+++ b/src/emcc-lua
@@ -30,6 +30,17 @@ def __get_uname():
 
     return uname
 
+def __get_output(output, entry_file):
+    out_file = os.path.basename(entry_file)
+    if output.get('file'):
+        out_file = output.get('file')
+
+    tpl = os.path.splitext(out_file)[1]
+    if not tpl[1]:
+        tpl[1] = 'html'
+
+    return '{}.{}'.format(tpl[0], tpl[1])
+
 def main():
     uname = __get_uname()
 
@@ -150,13 +161,12 @@ def main():
 
     # Finally, compile to wasm
     debug_print('Start to compile as WASM')
-    output_target = os.path.splitext(os.path.basename(entry_file))[0]
     cmd = ['emcc', '-Os', '-s', 'WASM=1']
     cmd.extend(['-I', quote('/lua-{}/src'.format(os.environ.get('LUA_VERSION')))])
     cmd.extend(['/tmp/compile.c', quote('/lua-{}/src/liblua.a'.format(os.environ.get('LUA_VERSION')))])
     cmd.extend([quote(v.filepath) for v in link_libraries])
     cmd.extend([quote(v.filepath) for v in link_libraries])
-    cmd.extend(['-lm', '-ldl', '-o', '{}.js'.format(output_target), '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["cwrap"]'])
+    cmd.extend(['-lm', '-ldl', '-o', definition.get_output_file(), '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["cwrap"]'])
 
     debug_print('Compile command is {}'.format(' '.join(cmd)))
     shell_exec(*cmd)

--- a/src/emcc_lua_lib/definition.py
+++ b/src/emcc_lua_lib/definition.py
@@ -4,26 +4,34 @@ import yaml
 from .helper import shell_exec, debug_print
 
 class Definition():
+    dependencies = []
+    functions = []
+    entry_file = ''
+    output_file = ''
+
     def __init__(self, definition_file):
         if not os.path.isfile(definition_file):
             print('{} is not exists. need to place it'.format(definition_file))
             sys.exit(1)
 
-        self.dependencies = []
-        self.functions = []
-        self.entry_file = ''
         with open(definition_file, mode='r') as definition:
             data = yaml.load(definition)
             self.dependencies = data.get('dependencies', [])
-            self.functions = data.get('functions', {})
+            self.functions = data.get('functions', [])
             self.entry_file = data.get('entry_file', '')
-
+            self.output_file = data.get('output_file', '')
 
     def get_entry_file(self):
         if not self.entry_file:
             return os.path.join(os.getcwd(), 'main.lua')
 
         return os.path.abspath(self.entry_file)
+
+    def get_output_file(self):
+        if self.output_file:
+            return self.output_file
+
+        return '{}.html'.format(os.path.splitext(os.path.basename(self.entry_file))[0])
 
 
     def install_dependencies(self, local_module_dir):


### PR DESCRIPTION
Enable to determine output file name.

```yml
# defnition.yml
...
output_file: output.html
```

Now we only support `.html` or `.js` because WASM binary which is created by emscripen, it requires glue code of JavaScript.