### PR TITLE
use emsdk image, support extra build args for emcc-lua

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM trzeci/emscripten
+FROM emscripten/emsdk:3.1.14
 LABEL maintainer "yoshiaki sugimoto <sugimoto@wnotes.net>"
 
 RUN apt-get update -qq -y
@@ -8,19 +8,8 @@ ENV LUA_VERSION 5.3.4
 ENV LUAROCKS_VERSION 2.4.4
 ENV PYTHON_VERSION 3.6.6
 
-# Install python3.6
-RUN cd /tmp && \
-  wget https://www.python.org/ftp/python/3.6.6/Python-${PYTHON_VERSION}.tgz && \
-  tar xfz Python-${PYTHON_VERSION}.tgz && \
-  cd Python-${PYTHON_VERSION} && \
-  ./configure --enable-optimizations && \
-  make -j8 && \
-  make altinstall
-
-RUN alias python='/usr/local/bin/python3.6'
-
 # Intall yaml
-RUN pip3.6 install pyyaml
+RUN pip3 install pyyaml
 
 # Install lua runtime
 RUN cd / && \
@@ -44,7 +33,7 @@ RUN cd /lua-${LUA_VERSION} && \
 
 # Install commands
 COPY ./src/emcc-lua /usr/local/bin/emcc-lua
-COPY ./src/emcc_lua_lib /opt/emcc_lua_lib
+COPY ./src/emcc_lua_lib /usr/local/emcc-lua/emcc_lua_lib
 COPY ./src/main.c /opt/main.c
 COPY ./src/main.lua /opt/main.lua
 RUN chmod +x /usr/local/bin/emcc-lua

--- a/src/emcc-lua
+++ b/src/emcc-lua
@@ -1,15 +1,14 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python3
 
 import sys
 import os
 import glob
 import re
 import shutil
-import yaml
 from shlex import quote
 import subprocess
 
-sys.path.append('/opt')
+sys.path.append('/usr/local/emcc-lua')
 
 from emcc_lua_lib.definition import Definition
 from emcc_lua_lib.file import LuaFile, ModuleFile, BundleFile
@@ -162,11 +161,12 @@ def main():
     # Finally, compile to wasm
     debug_print('Start to compile as WASM')
     cmd = ['emcc', '-Os', '-s', 'WASM=1']
+    cmd.extend(definition.get_extra_args())
     cmd.extend(['-I', quote('/lua-{}/src'.format(os.environ.get('LUA_VERSION')))])
     cmd.extend(['/tmp/compile.c', quote('/lua-{}/src/liblua.a'.format(os.environ.get('LUA_VERSION')))])
     cmd.extend([quote(v.filepath) for v in link_libraries])
     cmd.extend([quote(v.filepath) for v in link_libraries])
-    cmd.extend(['-lm', '-ldl', '-o', definition.get_output_file(), '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["cwrap"]'])
+    cmd.extend(['-lm', '-ldl', '-o', definition.get_output_file(), '-s', 'EXPORTED_RUNTIME_METHODS=["cwrap"]'])
 
     debug_print('Compile command is {}'.format(' '.join(cmd)))
     shell_exec(*cmd)

--- a/src/emcc_lua_lib/definition.py
+++ b/src/emcc_lua_lib/definition.py
@@ -8,24 +8,43 @@ class Definition():
     functions = []
     entry_file = ''
     output_file = ''
+    extra_compile_arguments = {}
+    pre_js = ''
 
     def __init__(self, definition_file):
         if not os.path.isfile(definition_file):
-            print('{} is not exists. need to place it'.format(definition_file))
+            print('{} does not exist. need to place it'.format(definition_file))
             sys.exit(1)
 
         with open(definition_file, mode='r') as definition:
-            data = yaml.load(definition)
+            data = yaml.safe_load(definition)
             self.dependencies = data.get('dependencies', [])
             self.functions = data.get('functions', [])
             self.entry_file = data.get('entry_file', '')
             self.output_file = data.get('output_file', '')
+            self.extra_compile_arguments = data.get('extra_args', {})
+            self.pre_js = data.get('pre_js', '')
 
     def get_entry_file(self):
         if not self.entry_file:
             return os.path.join(os.getcwd(), 'main.lua')
 
         return os.path.abspath(self.entry_file)
+
+    def get_extra_args(self):
+        args = []
+        for key, val in self.extra_compile_arguments.items():
+            args.extend(['-s', '{}={}'.format(key, val)])
+
+        if self.pre_js:
+            if not os.path.isfile(self.pre_js):
+                print('pre_js: {} does not exist. need to place it'.format(self.pre_js))
+                sys.exit(1)
+
+            args.extend(['--pre-js', self.pre_js])
+
+        return args
+
 
     def get_output_file(self):
         if self.output_file:


### PR DESCRIPTION
### Change base image

This PR changes base image, use `emscripten/emsdk:3.1.14` instead of `trzeci/emscripten` because `trzeci/emscripten` has been deprecated

FYI: https://hub.docker.com/r/trzeci/emscripten

Additionally, the `emscripten/emsdk:3.1.14` image contains python 3.8.11 so no longer we need to install manually.

### Support extra argument on build

`extra_args` in `definition.yaml`, that is defined dictionary could append to actual `emcc` command:

```yaml
...
extra_args:
  ENVIRONMENT: web  # then add -s ENVIRONMENT=web argument in emcc command

pre_js: /path/to/prepend.js   # then add --pre-js /path/to/prepend.js argument in emcc command
```

Entirely these change aims to support lua wasm on cloudflare workers.